### PR TITLE
Add project requests template

### DIFF
--- a/project-requests/create-project.yml
+++ b/project-requests/create-project.yml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Template
+labels:
+  template: projectrequest-template
+message: |-
+  The following project/namespace has been created: ${NAMESPACE}
+metadata:
+  annotations:
+    description: |-
+      ProjectRequest Template
+  name: ${NAMESPACE}
+objects:
+- apiVersion: v1
+  kind: ProjectRequest
+  metadata:
+    name: ${NAMESPACE}
+  description: '${NAMESPACE_DESCRIPTION}' 
+  displayName: '${NAMESPACE_DISPLAY_NAME}'
+parameters:
+- description: Name
+  displayName: Name
+  name: NAMESPACE
+  required: true
+- description: DisplayName
+  displayName: DisplayName
+  name: NAMESPACE_DISPLAY_NAME
+  required: true
+- description: Description
+  displayName: Description
+  name: NAMESPACE_DESCRIPTION


### PR DESCRIPTION
In an effort to reduce the number of random locations on the Internet that labs-ci-cd pulls templates from, I am moving the project requests one inline with this repo before the Big Move.