### PR TITLE
Update for more useful parameter names inside of secret-generic-opaque

### DIFF
--- a/secrets/secret-generic-opaque.yml
+++ b/secrets/secret-generic-opaque.yml
@@ -9,16 +9,16 @@ objects:
 - apiVersion: v1
   type: Opaque
   data:
-    ${FILE_NAME}: ${SECRET_VALUE}
+    ${SECRET_KEY}: ${SECRET_VALUE}
   kind: Secret
   metadata:
     labels:
       credential.sync.jenkins.openshift.io: true
     name: ${SECRET_NAME}
 parameters:
-- description: The filename of the secret
-  displayName: The filename of the secret
-  name: FILE_NAME
+- description: The name of the key used inside of the secret
+  displayName: The name of the key used inside of the secret
+  name: SECRET_KEY
   required: true
 - description: The name for the newly created secret
   displayName: Secret name


### PR DESCRIPTION
Changes the parameter `FILE_NAME` to be `SECRET_KEY` 

Resolves #21 