### PR TITLE
Fixing expected parameter format as this must be a non-string parameter

### DIFF
--- a/scc/project-run-anyuid-template.yml
+++ b/scc/project-run-anyuid-template.yml
@@ -20,7 +20,7 @@ objects:
   fsGroup:
     type: RunAsAny
   apiVersion: v1
-  priority: "${{PRIORITY_LEVEL}}"
+  priority: ${{PRIORITY_LEVEL}}
   volumes:
   - configMap
   - downwardAPI

--- a/scc/project-run-anyuid-template.yml
+++ b/scc/project-run-anyuid-template.yml
@@ -20,7 +20,7 @@ objects:
   fsGroup:
     type: RunAsAny
   apiVersion: v1
-  priority: "${PRIORITY_LEVEL}"
+  priority: "${{PRIORITY_LEVEL}}"
   volumes:
   - configMap
   - downwardAPI


### PR DESCRIPTION
Fixing template 'scc/project-run-anyuid-template.yml' for a non-string parameter required which is translated right now as a string.