### PR TITLE
s2i-build-template-binary-to-dockerimage-with-pull-and-push-secrets.yaml - init add

### DIFF
--- a/app-build/s2i-build-template-binary-to-dockerimage-with-pull-and-push-secrets.yaml
+++ b/app-build/s2i-build-template-binary-to-dockerimage-with-pull-and-push-secrets.yaml
@@ -1,0 +1,85 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: "${NAME}"
+  annotations:
+    openshift.io/display-name: Generic S2I Build to a remote docker repository using a push secret
+objects:
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      application: "${NAME}"
+      template: s2i-build-template-with-push-secret
+    name: "${NAME}"
+  spec:
+    failedBuildsHistoryLimit: 5
+    nodeSelector: null
+    output:
+      pushSecret:
+        name: "${PUSH_SECRET}"
+      to:
+        kind: DockerImage
+        name: "${DESTINATION_REPO_NAME}/${DESTINATION_REPO_NAMESPACE}/${DESTINATION_IMAGE_NAME}:${DESTINATION_IMAGE_TAG}"
+    postCommit: {}
+    resources: {}
+    runPolicy: Serial
+    source:
+      binary: {}
+      type: Binary
+    strategy:
+      sourceStrategy:
+        env:
+          - name: MAVEN_MIRROR_URL
+            value: "${MAVEN_MIRROR_URL}"
+          - name: MAVEN_ARGS_APPEND
+            value: "${MAVEN_ARGS_APPEND}"
+        forcePull: true
+        from:
+          kind: DockerImage
+          name: "${BUILDER_IMAGE_NAME}"
+        incremental: true
+        pullSecret:
+          name: "${PULL_SECRET}"
+      type: Source
+    successfulBuildsHistoryLimit: 5
+parameters:
+- name: NAME
+  displayName: Name
+  description: The name assigned to all objects.
+  required: true
+- name: PUSH_SECRET
+  displayName: Push Secret
+  description: The name of the secret that contains the authentication information for the docker repository you are pushing the docker image to.
+- name: PULL_SECRET
+  displayName: Pull Secret
+  description: The name of the secret that contains the authentication information for the docker repository you are pushing the docker image to.
+- name: DESTINATION_IMAGE_NAME
+  displayName: Destination Docker Image Name
+  description: The name of the image to be uploaded to the docker repository.
+  required: true
+- name: DESTINATION_REPO_NAME
+  displayName: Destination Docker Repo Name
+  description: The name of the repo the docker image will be uploaded to.
+  required: true
+- name: DESTINATION_IMAGE_TAG
+  displayName: Destination Docker Image Tag
+  description: The tag of the image to be uploaded to the docker repository.
+  required: true
+- name: DESTINATION_REPO_NAMESPACE
+  displayName: Destination Repository Namespace
+  description: The repository namespace that the image will be uploaded to.
+  required: true
+- name: BUILDER_IMAGE_NAME
+  displayName: Image name from which to build this pod
+  description: The build image which this build pod will extend to create it's new build pod type.
+  required: true
+- name: MAVEN_MIRROR_URL
+  displayName: Maven Mirror URL
+  description: Where your nexus lives
+  value: ""
+- name: MAVEN_ARGS_APPEND
+  displayName: Maven extra arguments
+  description: Additional parameters to pass to mvn command
+  value: ""


### PR DESCRIPTION
Wanted to merge this with `s2i-build-template-binary-to-dockerimage-with-push-secret.yaml` but from experimentation no way to use the template for just a push secret if you have the pull secret section specified but want to leave it blank. You end up with:

```
* spec.strategy.sourceStrategy.pullSecret.name: Required value
```

hence the need for two separate templates that are almost identical.