### PR TITLE
CREATED help README file to add missing details

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -1,0 +1,18 @@
+
+# Deploys the Prometheus using template
+
+### REQUIRED ARGUMENTS -- Need more details
+
+
+**1. NAMESPACE: Use to override the default namespace created under project**
+- More description are needed
+
+**2. RECORD_RULES: Point to record.rules as Secret object**
+- Help Documentation: <https://prometheus.io/docs/prometheus/latest/configuration/recording_rules>
+
+**3. PROM_CONFIG: Point to prometheus.yml as Secret object**
+- Example: <https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus.yml>
+
+**4. ALERT_CONFIG: Point to alertmanager.yml as Secret object**
+- Help Documentation: <https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules>
+


### PR DESCRIPTION
Running the Template file needs the additional information about how to get the required arguments

#### What is this PR About?
Deploying the Prometheus documentation is confusing as it misses the information about the required parameters.

#### How do we test this?
1. Create  a new project in Openshift using "oc new-project test-prometheus"
2. Deploy as a new app using either
 oc new-app -f template.yaml 

or 
oc process -f template.yaml  > resource.yaml
then 
oc create -f resource.yaml

cc: @redhat-cop/day-in-the-life
