### PR TITLE
Nexus: Add lifecycle handler for adding repositories

### DIFF
--- a/nexus/nexus-deployment-template.yml
+++ b/nexus/nexus-deployment-template.yml
@@ -56,11 +56,16 @@ objects:
       metadata:
         labels:
           name: "${NAME}"
+          app: "${NAME}"
       spec:
         containers:
         - image: "${NAME}"
           imagePullPolicy: Always
           name: "${NAME}"
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "/repos/repos.sh"]
           readinessProbe:
             httpGet:
               path: /
@@ -85,6 +90,9 @@ objects:
           volumeMounts:
           - mountPath: "/nexus-data"
             name: "${NAME}"
+          - name: "${NAME}-cm"
+            readOnly: true
+            mountPath: /repos
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext:
@@ -95,6 +103,10 @@ objects:
         - persistentVolumeClaim:
             claimName: "${NAME}"
           name: "${NAME}"
+        - name: "${NAME}-cm"
+          configMap:
+            name: "${NAME}-cm"
+            defaultMode: 365
     test: false
     triggers:
     - type: ConfigChange
@@ -140,6 +152,25 @@ objects:
       name: "${NAME}"
       weight: 100
     wildcardPolicy: None
+- apiVersion: v1
+  data:
+    repos.sh: |+
+      echo "`date +%Y-%m-%d-%T` running repos.sh postStart lifecycle " > /nexus-data/lifecycle.log
+      timeout 240 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8081/)" != "200" ]]; do echo "`date +%Y-%m-%d-%T` waiting for nexus startup" >> /nexus-data/lifecycle.log; sleep 3; done'
+      test -e /nexus-data/admin.password && export PW=$(cat /nexus-data/admin.password) || export PW=admin123
+      curl -u admin:$PW -X DELETE  -H 'accept: application/json' localhost:8081/${NEXUS_BASE_API_URL}/script/repos 
+      curl -u admin:$PW -H 'Content-Type: application/json' -H 'Accept: application/json' -d '@/repos/repos.json' localhost:8081/${NEXUS_BASE_API_URL}/script 
+      curl -u admin:$PW -H 'Content-Type: text/plain' -H 'accept: application/json' -d '' localhost:8081/${NEXUS_BASE_API_URL}/script/repos/run
+      echo "`date +%Y-%m-%d-%T` finished running repos.sh postStart lifecycle " >> /nexus-data/lifecycle.log
+    repos.json: |+
+      {
+        "name": "repos",
+        "content": "import org.sonatype.nexus.blobstore.api.BlobStoreManager; import org.sonatype.nexus.repository.manager.RepositoryManager; import org.sonatype.nexus.repository.maven.LayoutPolicy; import org.sonatype.nexus.repository.maven.VersionPolicy; import org.sonatype.nexus.repository.storage.WritePolicy; if ( !repository.repositoryManager.exists( 'custom-snapshots' ) ){ repository.createMavenHosted( 'custom-snapshots', BlobStoreManager.DEFAULT_BLOBSTORE_NAME, true, VersionPolicy.SNAPSHOT, WritePolicy.ALLOW, LayoutPolicy.STRICT); }; if ( !repository.repositoryManager.exists( 'custom-releases' ) ){ repository.createMavenHosted( 'custom-releases', BlobStoreManager.DEFAULT_BLOBSTORE_NAME, true, VersionPolicy.RELEASE, WritePolicy.ALLOW_ONCE, LayoutPolicy.STRICT); }; if ( !repository.repositoryManager.exists( 'custom-static' ) ){ repository.createRawHosted('custom-static'); }; if ( !repository.repositoryManager.exists( 'jenkins-public' ) ){ repository.createMavenProxy('jenkins-public','http://repo.jenkins-ci.org/public'); }; if ( !repository.repositoryManager.exists( 'custom-public' ) ){ repository.createMavenGroup('custom-public', ['custom-releases','custom-snapshots', 'jenkins-public']); }; if ( !repository.repositoryManager.exists( 'npm-all' ) ) { repository.createNpmHosted('npm-all'); }; if ( !repository.repositoryManager.exists( 'npm-registry' ) ) { repository.createNpmProxy('npm-registry','https://registry.npmjs.org'); }; if ( !repository.repositoryManager.exists( 'npm-group' ) ) { repository.createNpmGroup('npm-group',['npm-all','npm-registry']); }; if ( !repository.repositoryManager.exists( 'pypi-internal' ) ) { repository.createPyPiHosted('pypi-internal'); }; if ( !repository.repositoryManager.exists( 'pypi-proxy' ) ) { repository.createPyPiProxy('pypi-proxy','https://pypi.org/'); }; if ( !repository.repositoryManager.exists( 'pypi-all' ) ) { repository.createPyPiGroup('pypi-all',['pypi-internal','pypi-proxy']); }; if ( !repository.repositoryManager.exists( 'mulesoft-release' ) ){ repository.createMavenProxy('mulesoft-release','http://repository.mulesoft.org/releases/'); }; if ( !repository.repositoryManager.exists( 'codehaus-mirror' ) ){ repository.createMavenProxy('codehaus-mirror','https://repository.mulesoft.org/nexus/content/repositories/public'); }; if ( repository.repositoryManager.exists( 'maven-public' ) ) { repository.repositoryManager.delete('maven-public'); }; if ( !repository.repositoryManager.exists( 'nist-proxy-repos' ) ) { repository.createRawProxy( 'nist-proxy-repos', 'https://nvd.nist.gov/feeds/', BlobStoreManager.DEFAULT_BLOBSTORE_NAME); }; if ( !repository.repositoryManager.exists( 'jboss-public' ) ){ repository.createMavenProxy('jboss-public','https://repository.jboss.org/nexus/content/groups/public/'); }; if ( !repository.repositoryManager.exists( 'redhat-ga' ) ){ repository.createMavenProxy('redhat-ga','https://maven.repository.redhat.com/ga/'); }; if ( !repository.repositoryManager.exists( 'redhat-earlyaccess-all' ) ){ repository.createMavenProxy('redhat-earlyaccess-all','https://maven.repository.redhat.com/earlyaccess/all/'); }; if ( !repository.repositoryManager.exists( 'redhat-public' ) ){ repository.createMavenGroup('redhat-public', ['jboss-public','redhat-earlyaccess-all','redhat-ga']); }; repository.createMavenGroup('maven-public',['custom-public','redhat-public','maven-releases', 'maven-snapshots', 'maven-central', 'mulesoft-release', 'codehaus-mirror']);",
+        "type": "groovy"
+      }
+  kind: ConfigMap
+  metadata:
+    name: "${NAME}-cm"
 parameters:
 - name: NAME
   displayName: Name
@@ -159,5 +190,9 @@ parameters:
   displayName: Nexus Container Image
   name: CONTAINER_IMAGE
   value: sonatype/nexus3:3.7.1
+- description: The url base for the Nexus API which has been known to change between release
+  displayName: Nexus Base API URL
+  name: NEXUS_BASE_API_URL
+  value: service/siesta/rest/v1
 labels:
   template: nexus-persistent-template


### PR DESCRIPTION
#### What is this PR About?
Gives the ability to run a poststart lifecyle event to add repositories to the nexus repo manager at startup. This kicks off a script that connects to the API. This version avoids running in a separate pod like the last version did (which led to a shared volume issue). Instead, this runs on the same pod

#### How do we test this?
For older versions of nexus (3.7.1)

```
oc process -f nexus/nexus-deployment-template.yml -p VOLUME_CAPACITY=5Gi | oc apply -f - -n your_namespace
```
For newer versions (3.18.1)

```
oc process -f nexus-deployment-template.yml -p CONTAINER_IMAGE=sonatype/nexus3:3.18.1 -p NEXUS_BASE_API_URL=service/rest/v1 -p VOLUME_CAPACITY=5Gi | oc apply -f - -n your_namespace
```

cc: @redhat-cop/day-in-the-life, @pabrahamsson, @pcarney8 
