### PR TITLE
Add cluster monitoring templates

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -1,0 +1,13 @@
+# Prometheus
+
+This directory contains templates relating to Prometheus and other metrics/monitoring tooling
+
+## General
+
+- [Prometheus.yml](prometheus.yml) - A template that can be used to deploy a single instance of Prometheus
+
+## Openshift 4
+In OCP 4.X -- a monitoring stack is deployed by default in the `openshift-monitoring` namespace for cluster monitoring only. The following can be used to configure different settings for this monitoring stack:
+
+- [Ephemeral Cluster Monitoring](ephemeral-cluster-monitoring.yml) - Configures the monitoring stack so that it doesn't persist metrics after a restart. Allows you to set a retention period for metrics in Prometheus.
+- [Persistent Cluster Monitoring.yml](persistent-cluster-monitoring.yml) - Configures the monitoring stack so that you are able to persist data for Prometheus and Alertmanager throughout restarts. Allows you to set a retention period for metrics in Prometheus.

--- a/prometheus/ephemeral-cluster-monitoring.yml
+++ b/prometheus/ephemeral-cluster-monitoring.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: ephemeral-cluster-monitoring-template
+metadata:
+  name: ephemeral-cluster-monitoring
+objects:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: cluster-monitoring-config
+    namespace: openshift-monitoring
+  data:
+    config.yaml: |
+      prometheusK8s:
+        retention: ${PROMETHEUS_RETENTION_PERIOD}
+parameters:
+- description: Retention period for Prometheus Metrics -- (h)ours, (d)ays or (w)eeks
+  name: PROMETHEUS_RETENTION_PERIOD
+  value: 4d

--- a/prometheus/persistent-cluster-monitoring.yml
+++ b/prometheus/persistent-cluster-monitoring.yml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: persistent-cluster-monitoring-template
+metadata:
+  name: persistent-cluster-monitoring
+objects:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: cluster-monitoring-config
+    namespace: openshift-monitoring
+  data:
+    config.yaml: |
+      prometheusK8s:
+        retention: ${PROMETHEUS_RETENTION_PERIOD}
+        volumeClaimTemplate:
+          metadata:
+            name: ${PROMETHEUS_VOLUME_NAME}
+          spec:
+            storageClassName: ${PROMETHEUS_STORAGE_CLASS}
+            resources:
+              requests:
+                storage: ${PROMETHEUS_VOLUME_CAPACITY}
+      alertmanagerMain:
+        volumeClaimTemplate:
+          metadata:
+            name: ${ALERTMANAGER_VOLUME_NAME}
+          spec:
+            storageClassName: ${ALERTMANAGER_STORAGE_CLASS}
+            resources:
+              requests:
+                storage: ${ALERTMANAGER_VOLUME_CAPACITY}
+parameters:
+- description: Name of Prometheus PVC to create
+  name: PROMETHEUS_VOLUME_NAME
+  value: cluster-monitoring-prometheus-volume
+- description: Retention period for Prometheus Metrics -- (h)ours, (d)ays or (w)eeks
+  name: PROMETHEUS_RETENTION_PERIOD
+  value: 4d
+- description: storage class to use for Prometheus PVC
+  required: true
+  name: PROMETHEUS_STORAGE_CLASS
+- description: Size of volume to create for Prometheus
+  name: PROMETHEUS_VOLUME_CAPACITY
+  value: 5Gi
+- description: Name of Alertmanager PVC to create
+  name: ALERTMANAGER_VOLUME_NAME
+  value: cluster-monitoring-alertmanager-volume
+- description: storage class to use for Alertmanager PVC
+  name: ALERTMANAGER_STORAGE_CLASS
+  required: true
+- description: Size of volume to create for Alertmanager
+  name: ALERTMANAGER_VOLUME_CAPACITY
+  value: 5Gi


### PR DESCRIPTION
#### What is this PR About?
Adds templates to configure ephemeral or persistent cluster-monitoring stack as well as the ability to tune the retention period of metrics in Prometheus.


cc: @redhat-cop/day-in-the-life
