### PR TITLE
Add plain namespace template

### DIFF
--- a/namespace/create-namespace.yml
+++ b/namespace/create-namespace.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Template
+labels:
+  template: namespace-template
+message: |-
+  The following project/namespace has been created: ${NAMESPACE}
+metadata:
+  name: namespace-template 
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: "${NAMESPACE}"
+parameters:
+- name: NAMESPACE
+  required: true
+  description: The name of the namespace that you wish to create 


### PR DESCRIPTION
#### What is this PR About?
This adds a plain namespace template that allows us to get around situations where we need to create a project that is prefixed with `openshift-` (specifically the current use case of creating the project that needs to hold all of the logging components in OCP v4).

#### How do we test this?
`oc process -f create-namespace.yml -p NAMESPACE=openshift-logging-test | oc apply -f -`

cc: @redhat-cop/day-in-the-life
