### PR TITLE
Jenkins slack

### DIFF
--- a/jenkins/jenkins-ephemeral-template.yml
+++ b/jenkins/jenkins-ephemeral-template.yml
@@ -84,8 +84,10 @@ objects:
                   value: ${SLACK_BASE_URL}
                 - name: SLACK_ROOM
                   value: ${SLACK_ROOM}
-                - name: SLACK_TOKEN
-                  value: ${SLACK_TOKEN}
+                - name: SLACK_TEAM
+                  value: ${SLACK_TEAM}
+                - name: SLACK_TOKEN_CREDENTIAL_ID
+                  value: ${SLACK_TOKEN_CREDENTIAL_ID}
                 - name: SHARED_LIB_REPO
                   value: ${SHARED_LIB_REPO}
                 - name: SHARED_LIB_NAME
@@ -258,12 +260,15 @@ parameters:
   - description: The integration point with slack
     displayName: Slack Base URL
     name: SLACK_BASE_URL
+  - description: The default slack team
+    displayName: Default Slack Team
+    name: SLACK_TEAM
   - description: The default slack channel
     displayName: Default Slack Channel
     name: SLACK_ROOM
   - description: Slack Token
-    displayName: Slack Token
-    name: SLACK_TOKEN
+    displayName: The id of a secret that is sync'd to Jenkins that contains the token in secrettext
+    name: SLACK_TOKEN_CREDENTIAL_ID
   - description: Jenkins Shared Library Repository URL
     displayName: Jenkins Shared Library Repo URL
     name: SHARED_LIB_REPO

--- a/jenkins/jenkins-persistent-template.yml
+++ b/jenkins/jenkins-persistent-template.yml
@@ -94,8 +94,10 @@ objects:
                   value: ${SLACK_BASE_URL}
                 - name: SLACK_ROOM
                   value: ${SLACK_ROOM}
-                - name: SLACK_TOKEN
-                  value: ${SLACK_TOKEN}
+                - name: SLACK_TOKEN_CREDENTIAL_ID
+                  value: ${SLACK_TOKEN_CREDENTIAL_ID}
+                - name: SLACK_TEAM
+                  value: ${SLACK_TEAM}
                 - name: SHARED_LIB_REPO
                   value: ${SHARED_LIB_REPO}
                 - name: SHARED_LIB_NAME

--- a/jenkins/jenkins-persistent-template.yml
+++ b/jenkins/jenkins-persistent-template.yml
@@ -277,12 +277,15 @@ parameters:
   - description: The integration point with slack
     displayName: Slack Base URL
     name: SLACK_BASE_URL
+  - description: The default slack team
+    displayName: Default Slack Team
+    name: SLACK_TEAM
   - description: The default slack channel
     displayName: Default Slack Channel
     name: SLACK_ROOM
   - description: Slack Token
-    displayName: Slack Token
-    name: SLACK_TOKEN
+    displayName: The id of a secret that is sync'd to Jenkins that contains the token in secrettext
+    name: SLACK_TOKEN_CREDENTIAL_ID
   - description: Jenkins Shared Library Repository URL
     displayName: Jenkins Shared Library Repo URL
     name: SHARED_LIB_REPO


### PR DESCRIPTION
#### What is this PR About?
Updates the Jenkins Slack integration points by changing the env var of slack_token to a reference to a slack token secret which is the preferred way and the old way was broken. Also adds another option for the slack team that can be specified in the plugin.

See this pull request in for usage https://github.com/rht-labs/s2i-config-jenkins/pull/18

#### How do we test this?
Will work if no slack integration exists. Would require a slack instance with jenkins app integration. Then a build based of the PR above and deployment using this update template and adding params 
```
    SLACK_ROOM: jenkins
    SLACK_TOKEN_CREDENTIAL_ID: "slack-token_id"
    SLACK_BASE_URL: https://xxxxxxxxxxx.slack.com/services/hooks/jenkins-ci/
    SLACK_TEAM: xxxxxxxx-optional
```

cc: @redhat-cop/day-in-the-life
