### PR TITLE
Add (Cluster)Rolebinding templates, fixes #68

### DIFF
--- a/role-bindings/group-cluster-rolebinding-template.yml
+++ b/role-bindings/group-cluster-rolebinding-template.yml
@@ -2,15 +2,15 @@
 kind: Template
 apiVersion: v1
 metadata:
-  name: add-role-to-group
+  name: add-cluster-role-to-group
   annotations:
-    openshift.io/display-name: Group and role binding Access template
-    description: RoleBinding to give access to project
+    openshift.io/display-name: Group and cluster-role binding Access template
+    description: ClusterRoleBinding to give access to resources
 labels:
-  template: role-to-group-binding
+  template: cluster-role-to-group-binding
 objects:
 - apiVersion: v1
-  kind: RoleBinding
+  kind: ClusterRoleBinding
   metadata:
     name: "${GROUP}_${ROLE}_role"
   roleRef:
@@ -25,7 +25,7 @@ parameters:
   displayName: Role
   description: The role to bind to the group
   required: true
-  value: edit
+  value: basic-user
 - name: GROUP
   displayName: Group
   description: The group to bind to the role

--- a/role-bindings/user-cluster-rolebinding-template.yml
+++ b/role-bindings/user-cluster-rolebinding-template.yml
@@ -1,0 +1,32 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: add-cluster-role-to-user
+  annotations:
+    openshift.io/display-name: User and cluster-role binding Access template
+    description: ClusterRoleBinding to give access to resources
+labels:
+  template: cluster-role-to-user-binding
+objects:
+- apiVersion: v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: "${USER}_${ROLE}_role"
+  roleRef:
+    name: "${ROLE}"
+  subjects:
+  - kind: User
+    name: "${USER}"
+  userNames:
+  - "${USER}"
+parameters:
+- name: ROLE
+  displayName: Role
+  description: The role to bind to the user
+  required: true
+  value: basic-user
+- name: USER
+  displayName: User
+  description: The user to bind to the role
+  required: true

--- a/role-bindings/user-rolebinding-template.yml
+++ b/role-bindings/user-rolebinding-template.yml
@@ -1,0 +1,32 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: add-role-to-user
+  annotations:
+    openshift.io/display-name: User and role binding Access template
+    description: RoleBinding to give access to project
+labels:
+  template: role-to-user-binding
+objects:
+- apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: "${USER}_${ROLE}_role"
+  roleRef:
+    name: "${ROLE}"
+  subjects:
+  - kind: User
+    name: "${USER}"
+  userNames:
+  - "${USER}"
+parameters:
+- name: ROLE
+  displayName: Role
+  description: The role to bind to the user
+  required: true
+  value: edit
+- name: USER
+  displayName: User
+  description: The user to bind to the role
+  required: true


### PR DESCRIPTION
#### What is this PR About?
Added templates for user/group ClusterRoleBindings and also user RoleBinding.
Also minor tweaks to the existing group RoleBinding.

#### How do we test this?
```
oc process -f <template> -p ROLE=<role> -p <GROUP|USER>=<group|user> | oc apply -f -
```

cc: @redhat-cop/day-in-the-life
