### PR TITLE
Add two templates for creating PVCs

### DIFF
--- a/storage/persistent-volume-claim-default-storageclass.yml
+++ b/storage/persistent-volume-claim-default-storageclass.yml
@@ -1,0 +1,33 @@
+
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: pvc-template-default-storageclass
+objects:
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${PVC_NAME}
+  spec:
+    accessModes:
+      - ${PVC_ACCESS_MODE}
+    volumeMode: ${PVC_VOLUME_MODE}
+    resources:
+      requests:
+        storage: ${PVC_SIZE}
+parameters:
+- description: The name of the PVC
+  name: PVC_NAME
+  required: true
+- description: The PVC access mode (RWO, ROX, RWX)
+  name: PVC_ACCESS_MODE
+  required: true
+  value: ReadWriteOnce
+- description: Use as filesystem or block device
+  name: PVC_VOLUME_MODE
+  required: false
+  value: Filesystem
+- description: The requested minimum volume capacity.
+  name: PVC_SIZE
+  required: true

--- a/storage/persistent-volume-claim.yml
+++ b/storage/persistent-volume-claim.yml
@@ -1,0 +1,37 @@
+
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: pvc-template
+objects:
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${PVC_NAME}
+  spec:
+    accessModes:
+      - ${PVC_ACCESS_MODE}
+    volumeMode: ${PVC_VOLUME_MODE}
+    resources:
+      requests:
+        storage: ${PVC_SIZE}
+    storageClassName: ${PVC_STORAGE_CLASS}
+parameters:
+- description: The name of the PVC
+  name: PVC_NAME
+  required: true
+- description: The PVC access mode (RWO, ROX, RWX)
+  name: PVC_ACCESS_MODE
+  required: true
+  value: ReadWriteOnce
+- description: Use as filesystem or block device
+  name: PVC_VOLUME_MODE
+  required: false
+  value: Filesystem
+- description: The requested minimum volume capacity.
+  name: PVC_SIZE
+  required: true
+- description: The requested storage class to use
+  name: PVC_STORAGE_CLASS
+  required: true


### PR DESCRIPTION
#### What is this PR About?
Adds two templates for creating PVC, default storage class & specified storage class

#### How do we test this?
```
# Declared storage class
oc process -f storage/persistent-volume-claim.yml -p PVC_NAME=pvc1 -p PVC_SIZE=1Gi -p PVC_STORAGE_CLASS=gp2

# Default storage class
oc process -f storage/persistent-volume-claim.yml -p PVC_NAME=pvc1 -p PVC_SIZE=1Gi
```

cc: @redhat-cop/day-in-the-life
