### PR TITLE
Added new installplan approver job template

### DIFF
--- a/operatorhub/installplan-approve-one-installplan-job-template.yml
+++ b/operatorhub/installplan-approve-one-installplan-job-template.yml
@@ -32,8 +32,10 @@ objects:
                     export installplan=$(oc get installplan -o=jsonpath='{.items[0].metadata.name}')
                     echo "Found ${installplan}.."
                     if [ $(oc get installplan $installplan -o jsonpath="{.spec.approved}") = "false" ]; then
-                       oc patch installplan $installplan -n ${NAMESPACE} --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
-                       echo "${installplan} approved, job completed succesfully. Your operator should now be in the process of installation"
+                       sleep 5
+                       export installplan_c=$(oc get installplan -o=jsonpath='{.items[0].metadata.name}'
+                       oc patch installplan $installplan-_c -n ${NAMESPACE} --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
+                       echo "${installplan_c} approved, job completed succesfully. Your operator should now be in the process of installation"
                        break
                     fi
                     if [ $(oc get installplan $installplan -n ${NAMESPACE} -o jsonpath="{.spec.approved}") = "true" ]; then

--- a/operatorhub/installplan-approve-one-installplan-job-template.yml
+++ b/operatorhub/installplan-approve-one-installplan-job-template.yml
@@ -1,0 +1,75 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+message: |-
+  The following Job has been created: ${NAME}
+metadata:
+  name: installplan-approver-job-template
+objects:
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: ${NAME}
+    namespace: ${TARGET_NAMESPACE}
+  spec:
+    template:
+      spec:
+        containers:
+          - image: registry.redhat.io/openshift4/ose-cli:v4.4
+            command:
+              - /bin/bash
+              - -c
+              - |
+                export HOME=/tmp/approver
+                echo "Waiting for installPlan to be created"
+                while true; do
+                  sleep ${SLEEP}
+                  if [ $(oc get installplan --no-headers --ignore-not-found -n ${NAMESPACE} | wc -l) -gt 1 ]; then
+                     echo "More than one installPlan found, exiting the script to prevent unexpected behavior"
+                     break
+                  fi
+                  if [ $(oc get installplan --no-headers --ignore-not-found -n ${NAMESPACE} | wc -l) -gt 0 ]; then
+                    export installplan=$(oc get installplan -o=jsonpath='{.items[0].metadata.name}')
+                    echo "Found ${installplan}.."
+                    if [ $(oc get installplan $installplan -o jsonpath="{.spec.approved}") = "false" ]; then
+                       oc patch installplan $installplan -n ${NAMESPACE} --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
+                       echo "${installplan} approved, job completed succesfully. Your operator should now be in the process of installation"
+                       break
+                    fi
+                    if [ $(oc get installplan $installplan -n ${NAMESPACE} -o jsonpath="{.spec.approved}") = "true" ]; then
+                       echo "${installplan} already approved which is not expected, exiting without any action on installplan"
+                       break
+                    fi
+                  fi
+                done
+            imagePullPolicy: Always
+            name: ${NAME}
+            env:
+            - name: SLEEP
+              value: ${SLEEP}
+            - name: NAMESPACE
+              value: ${TARGET_NAMESPACE}
+            - name: WAIT_FOR_INSTALLPLAN
+              value: ${WAIT_FOR_INSTALLPLAN}
+            - name: INITIAL_SLEEP
+        dnsPolicy: ClusterFirst
+        restartPolicy: OnFailure
+        serviceAccount: ${SERVICE_ACCOUNT}
+        serviceAccountName: ${SERVICE_ACCOUNT}
+        terminationGracePeriodSeconds: 30
+        activeDeadlineSeconds: 3600
+parameters:
+- name: NAME
+  required: true
+  description: Name of the Job to create
+- name: TARGET_NAMESPACE
+  required: true
+  description: A namespace for the Job to target
+- name: SLEEP
+  required: false
+  description: Amount of time script should sleep for
+  value: "2"
+- name: SERVICE_ACCOUNT
+  required: false
+  value: "installplan-approver-job"
+  description: A ServiceAccount job will use

--- a/operatorhub/installplan-approver-job-template.yml
+++ b/operatorhub/installplan-approver-job-template.yml
@@ -21,62 +21,34 @@ objects:
               - -c
               - |
                 export HOME=/tmp/approver
-                if [ ${WAIT_FOR_INSTALLPLAN}  = "false" ]; then  
-                  echo "Approving operator install.  Waiting a few seconds to make sure the InstallPlan gets created first."
-                  sleep $SLEEP
-                  oc project $NAMESPACE
-                  for subscription in `oc get subscriptions.operators.coreos.com -o jsonpath='{.items[0].metadata.name}'`
-                  do
-                    echo "Processing subscription '$subscription'"
-                    installplan=$(oc get subscriptions.operators.coreos.com --field-selector metadata.name=${subscription} -o jsonpath='{.items[0].status.installPlanRef.name}')
-                    echo "Check installplan approved status"
-                    oc get installplan $installplan -o jsonpath="{.spec.approved}"
-                    if [ "`oc get installplan $installplan -o jsonpath="{.spec.approved}"`" == "false" ]; then
-                      echo "Approving Subscription $subscription with install plan $installplan"
-                      oc patch installplan $installplan --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
-                    else
-                      echo "Install Plan '$installplan' already approved"
-                    fi
-                  done
-                fi
-                if [ ${WAIT_FOR_INSTALLPLAN}  = "true" ]; then
-                  echo "Waiting for installPlan to be created"
-                  while true; do
-                    if [ $(oc get installplan --no-headers --ignore-not-found -n ${NAMESPACE} | wc -l) -gt 1 ]; then
-                       echo "More than one installPlan found, exiting the script to prevent unexpected behavior"
-                       break
-                    fi
-                    if [ $(oc get installplan --no-headers --ignore-not-found -n ${NAMESPACE} | wc -l) -gt 0 ]; then
-                      export installplan=$(oc get installplan -o=jsonpath='{.items[0].metadata.name}')
-                      echo "Found ${installplan}.."
-                      if [ $(oc get installplan $installplan -o jsonpath="{.spec.approved}") = "false" ]; then
-                         oc patch installplan $installplan -n ${NAMESPACE} --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
-                         echo "${installplan} approved, job completed succesfully. Your operator should now be in the process of installation"
-                         break
-                      fi
-                      if [ $(oc get installplan $installplan -n ${NAMESPACE} -o jsonpath="{.spec.approved}") = "true" ]; then
-                         echo "${installplan} already approved which is not expected, exiting without any action on installplan"
-                         break
-                      fi
-                    fi
-                    sleep ${SLEEP}
-                  done
-                fi
+                echo "Approving operator install.  Waiting a few seconds to make sure the InstallPlan gets created first."
+                sleep $SLEEP
+                oc project $NAMESPACE
+                for subscription in `oc get subscriptions.operators.coreos.com -o jsonpath='{.items[0].metadata.name}'`
+                do
+                  echo "Processing subscription '$subscription'"
+                  installplan=$(oc get subscriptions.operators.coreos.com --field-selector metadata.name=${subscription} -o jsonpath='{.items[0].status.installPlanRef.name}')
+                  echo "Check installplan approved status"
+                  oc get installplan $installplan -o jsonpath="{.spec.approved}"
+                  if [ "`oc get installplan $installplan -o jsonpath="{.spec.approved}"`" == "false" ]; then
+                    echo "Approving Subscription $subscription with install plan $installplan"
+                    oc patch installplan $installplan --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
+                  else
+                    echo "Install Plan '$installplan' already approved"
+                  fi
+                done
             imagePullPolicy: Always
-            name: ${NAME}
+            name: installplan-approver
             env:
             - name: SLEEP
-              value: ${SLEEP}
+              value: "20"
             - name: NAMESPACE
               value: ${TARGET_NAMESPACE}
-            - name: WAIT_FOR_INSTALLPLAN
-              value: ${WAIT_FOR_INSTALLPLAN}
         dnsPolicy: ClusterFirst
         restartPolicy: OnFailure
-        serviceAccount: ${SERVICE_ACCOUNT}
-        serviceAccountName: ${SERVICE_ACCOUNT}
+        serviceAccount: installplan-approver-job
+        serviceAccountName: installplan-approver-job
         terminationGracePeriodSeconds: 30
-        activeDeadlineSeconds: 3600
 parameters:
 - name: NAME
   required: true
@@ -84,15 +56,3 @@ parameters:
 - name: TARGET_NAMESPACE
   required: true
   description: A namespace for the Job to target
-- name: SLEEP
-  required: false
-  description: Amount of time script should sleep for
-  value: "20"
-- name: WAIT_FOR_INSTALLPLAN
-  required: false
-  description: 
-  value: "false"
-- name: SERVICE_ACCOUNT
-  required: false
-  value: "installplan-approver-job"
-  description: A ServiceAccount job will use


### PR DESCRIPTION

#### What is this PR About?
This PR adds new installplan approver job template for single installplan approval, it also reverts behavior of installplan-approver-job-template back to its original form

#### How do we test this?
Apply a job template using new template, observer if the installplan gets approved 

cc: @redhat-cop/day-in-the-life
